### PR TITLE
Feature/accept tab label key for fields

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -410,7 +410,7 @@ module DocusignRest
         tab_hash[:yPosition]  = tab[:y_position] || '0'
         tab_hash[:name]       = tab[:name] if tab[:name]
         tab_hash[:optional]   = false
-        tab_hash[:tabLabel]   = tab[:label] || 'Signature 1'
+        tab_hash[:tabLabel]   = tab[:label] || tab[:tab_label] || 'Signature 1'
         tab_hash[:width]      = tab[:width] if tab[:width]
         tab_hash[:height]     = tab[:height] if tab[:width]
         tab_hash[:value]      = tab[:value] if tab[:value]

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -358,7 +358,7 @@ module DocusignRest
           listTabs:             get_tabs(signer[:list_tabs], options, index),
           noteTabs:             nil,
           numberTabs:           nil,
-          radioGroupTabs:       nil,
+          radioGroupTabs:       get_group_tabs(signer[:radio_tabs], options, index),
           initialHereTabs:      get_tabs(signer[:initial_here_tabs], options.merge!(initial_here_tab: true), index),
           signHereTabs:         get_tabs(signer[:sign_here_tabs], options.merge!(sign_here_tab: true), index),
           signerAttachmentTabs: nil,
@@ -433,6 +433,21 @@ module DocusignRest
         tab_array << tab_hash
       end
       tab_array
+    end
+    
+    def get_group_tabs(tabs, options, index)
+      return [] if tabs.blank?
+      group_names = tabs.map { |t| t[:tab_label] }.uniq
+      group_names.map do |group_name|
+        first_tab_for_label = tabs.detect { |t| t[:tab_label].to_s == group_name.to_s }
+        {
+          groupName: group_name,
+          documentId: first_tab_for_label[:document_id] || '1',
+          pageNumber: first_tab_for_label[:page_number] || '1',
+          recipientId: index + 1,
+          radios: get_tabs(tabs, options, index)
+        }
+      end
     end
 
 

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -358,7 +358,7 @@ module DocusignRest
           listTabs:             get_tabs(signer[:list_tabs], options, index),
           noteTabs:             nil,
           numberTabs:           nil,
-          radioGroupTabs:       get_group_tabs(signer[:radio_tabs], options, index),
+          radioGroupTabs:       get_radio_group_tabs(signer[:radio_tabs], options, index),
           initialHereTabs:      get_tabs(signer[:initial_here_tabs], options.merge!(initial_here_tab: true), index),
           signHereTabs:         get_tabs(signer[:sign_here_tabs], options.merge!(sign_here_tab: true), index),
           signerAttachmentTabs: nil,
@@ -435,7 +435,7 @@ module DocusignRest
       tab_array
     end
     
-    def get_group_tabs(tabs, options, index)
+    def get_radio_group_tabs(tabs, options, index)
       return [] if tabs.blank?
       group_names = tabs.map { |t| t[:tab_label] }.uniq
       group_names.map do |group_name|


### PR DESCRIPTION
It adds the tab label as an input parameter and adds support for radio group tabs.

The structure for radio buttons we get when we export the docusign template is different than the one the API expects (who knows why did they design it in that way???), so needs special treatment.